### PR TITLE
Added execute and modified query to use conn.query

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ db2.query('SELECT * FROM users').spread(users => {
 
 
 ```
+## Enable DEBUG mode to log the query being executed and its parameters.
+
+``` js
+// You can enable debugging by passing the `debug` parameter as follow:
+// by default it is set to false.
+
+let config = {
+	host: "localhost",
+	user: "foo",
+	password: "bar",
+	database: "db",
+	debug: true;
+}
+```
+
+
 
 ## Example Usage of bulk
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install namshi-node-mysql --save
 
 ## Example Usage of query
 
-`query()` does not use prepared statements.
+`query()` uses [prepared statements](https://github.com/sidorares/node-mysql2#prepared-statements) but does not support bulk operations.
 
 ``` js
 
@@ -56,9 +56,9 @@ db2.query('SELECT * FROM users').spread(users => {
 
 ```
 
-## Example Usage of execute
+## Example Usage of bulk
 
-`execute()` uses [prepared statements](https://github.com/sidorares/node-mysql2#prepared-statements).
+`execute()`
 
 ``` js
 
@@ -69,9 +69,15 @@ let config = {
 	database: "db"
 }
 
+var values = [
+    ['demian', 'demian@gmail.com', 1],
+    ['john', 'john@gmail.com', 2],
+    ['mark', 'mark@gmail.com', 3],
+    ['pete', 'pete@gmail.com', 4]
+];
 let db = require('namshi-node-mysql')(config);
 
-db.execute('UPDATE foo SET key = ?', ['value']).then(() => {
+db.bulk('INSERT INTO Test (name, email, n) VALUES ?', [values]).then(() => {
 	return db.query('SELECT * FROM foo');
 }).spread(rows => {
 	console.log('Look at all the foo', rows);

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install namshi-node-mysql --save
 
 ## Example Usage of query
 
-`query()` uses [prepared-statements](https://github.com/sidorares/node-mysql2#prepared-statements).
+`query()` does not use prepared statements.
 
 ``` js
 
@@ -55,6 +55,30 @@ db2.query('SELECT * FROM users').spread(users => {
 
 
 ```
+
+## Example Usage of execute
+
+`execute()` uses [prepared statements](https://github.com/sidorares/node-mysql2#prepared-statements).
+
+``` js
+
+let config = {
+	host: "localhost",
+	user: "foo",
+	password: "bar",
+	database: "db"
+}
+
+let db = require('namshi-node-mysql')(config);
+
+db.execute('UPDATE foo SET key = ?', ['value']).then(() => {
+	return db.query('SELECT * FROM foo');
+}).spread(rows => {
+	console.log('Look at all the foo', rows);
+});
+
+```
+
 
 ## Example usage of [namedPlaceholders]((https://github.com/sidorares/node-mysql2#named-placeholders))
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ let instances = {};
 
 function DB() {
   this.pool = null;
+  this.debug = false;
 }
 
 function runQueryWith(methodName, query, params) {
@@ -12,6 +13,10 @@ function runQueryWith(methodName, query, params) {
   return this.getConnection().then((conn)=> {
     console.log('getting connection');
     connection = conn;
+
+    if (this.debug) {
+      console.info('QUERY AND PARAMS', query, params);
+    }
 
     return connection[methodName](query, params);
   }).then((results) => {
@@ -57,6 +62,11 @@ DB.prototype.getConnection = function () {
  * @param  {Object} config
  */
 DB.prototype.configure = function (config) {
+  if ('debug' in config) {
+    this.debug = config.debug;
+    delete config.debug;
+  }
+
   this.pool = mysql2.createPool(config);
 };
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
 /* jshint esversion: 6 */
-
-
 const mysql2 = require('mysql2/promise');
 let instances = {};
 
@@ -63,26 +61,26 @@ DB.prototype.configure = function (config) {
 };
 
 /**
- * Run DB query, it does not use preprared statements. But it supports batch
- * operations: https://github.com/mysqljs/mysql/pull/230
- * @param  {String} query
- * @param  {Object} [params]
- * @return {Promise}
- */
-DB.prototype.query = function(query, params) {
-  return runQueryWith('query', query, params);
-}
-
-
-/**
- * Run a DB query using prepared statements. This function does not batch
+ * Run a DB query using prepared statements. This function does not support batch
  * operations
  * @param  {String} query
  * @param  {Object} [params]
  * @return {Promise}
  */
-DB.prototype.execute = function(query, params) {
+DB.prototype.query = function(query, params) {
   return runQueryWith('execute', query, params);
+}
+
+
+/**
+ * Run a DB query without using prepared statements. This function supports batch
+ * operations
+ * @param  {String} query
+ * @param  {Object} [params]
+ * @return {Promise}
+ */
+DB.prototype.bulk = function(query, params) {
+  return runQueryWith('query', query, params);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Small wrapper for mysql2.",
   "main": "index.js",
   "scripts": {
-    "test": "jshint index.js && ./node_modules/.bin/mocha -t 2000",
+    "test": "./node_modules/.bin/mocha -t 2000",
     "release": "npm test && release-it -n -i patch",
     "release:minor": "npm test && release-it -n -i minor",
     "release:major": "npm test && release-it -n -i major"

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -9,6 +9,7 @@ describe('node-mysql', () => {
     const namedDb = require('../index')({host: 'mysql', name: 'foo'});
     namedDb.should.equal(require('../index')({host: 'mysql', name: 'foo'}));
     namedDb.should.have.property('query').which.is.a.Function;
+    namedDb.should.have.property('bulk').which.is.a.Function;
     namedDb.should.have.property('getConnection').which.is.a.Function;
     namedDb.should.have.property('startTransaction').which.is.a.Function;
     namedDb.should.have.property('commit').which.is.a.Function;


### PR DESCRIPTION
In our `DB.query()` function we were using mysql2's `execute()` which does not support [bulk operations](https://github.com/mysqljs/mysql/pull/230). In this PR, I changed it back to mysql2's `query()` and added `DB.execute()`. Now `DB.query()` supports bulk operations but not prepared statements while `DB.execute()` supports prepared statements but not bulk operations. 