### PR TITLE
Adding support for arrays' placeholders in prepared statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ function runQueryWith(query, params) {
   });
 }
 
+function flattenDeep(params) {
+    return Array.isArray(params) ? [].concat(...params.map(flattenDeep)) : params;
+}
+
 /**
  * Format a query as a preapred statement for bulk insert.
  *
@@ -106,7 +110,15 @@ DB.prototype.configure = function (config) {
  * @return {Promise}
  */
 DB.prototype.query = function(query, params) {
-  return runQueryWith.call(this, query, params);
+  let i = 0;
+  query = query.replace(/\?/g, function (match){
+    let param = params[i++];
+    if (Array.isArray(param)){
+      return Array(param.length).fill('?').join(',')
+    }
+    return '?';
+  });
+  return runQueryWith.call(this, query, flattenDeep(params));
 }
 
 

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -66,6 +66,83 @@ describe('node-mysql', () => {
     sinon.stub(db, 'configure').callsFake(function(config) { });
     sinon.stub(db, 'getConnection').resolves(connectionStub);
     db.bulk('INSERT INTO tbl_name (a,b,c) VALUES ?', [[1,2,3],[4,5, null]]).then(res => {
+      db.configure.restore();
+      db.getConnection.restore();
+      done();
+    }).catch(err => {
+      console.log('error: ', err);
+      assert.equal(err.message, 'should never reach here');
+      done();
+    });
+  });
+
+  it('should add extra placeholders in the prepared query if the corresponding param is an array. params sohuld be flatten if contain arrays.', (done) => {
+    const db = require('../index')({host: 'mysql', name: 'foo'});
+    const connectionStub = {
+      execute: function(query, params){
+        assert.equal(query, 'SELECT FROM tbl_name WHERE col_name IN (?,?,?) AND col_name_1 = ? AND col_name_2 IN (?,?) AND col_name_3 = ?');
+        assert.deepEqual(params, [1, 2, 3, null, 4, null, 5]);
+
+        return [];
+      },
+      release: function() { },
+      connection: {unprepare: function() {}}
+    };
+    sinon.stub(db, 'configure').callsFake(function(config) { });
+    sinon.stub(db, 'getConnection').resolves(connectionStub);
+    db.query('SELECT FROM tbl_name WHERE col_name IN (?) AND col_name_1 = ? AND col_name_2 IN (?) AND col_name_3 = ?', [[1,2,3],null,[4,null],5]).then(res => {
+      db.configure.restore();
+      db.getConnection.restore();
+      done();
+    }).catch(err => {
+      console.log('error: ', err);
+      assert.equal(err.message, 'should never reach here');
+      done();
+    });
+  });
+
+  it('should run the same input query if params do not include arrays. params remain the same as given.', (done) => {
+    const db = require('../index')({host: 'mysql', name: 'foo'});
+    const connectionStub = {
+      execute: function(query, params){
+        assert.equal(query, 'SELECT FROM tbl_name WHERE col_name = ? AND col_name_1 = ?');
+        assert.deepEqual(params, [1, 2]);
+
+        return [];
+      },
+      release: function() { },
+      connection: {unprepare: function() {}}
+    };
+    sinon.stub(db, 'configure').callsFake(function(config) { });
+    sinon.stub(db, 'getConnection').resolves(connectionStub);
+    db.query('SELECT FROM tbl_name WHERE col_name = ? AND col_name_1 = ?', [1, 2]).then(res => {
+      db.configure.restore();
+      db.getConnection.restore();
+      done();
+    }).catch(err => {
+      console.log('error: ', err);
+      assert.equal(err.message, 'should never reach here');
+      done();
+    });
+  });
+
+  it('should run the same query if no params provided.', (done) => {
+    const db = require('../index')({host: 'mysql', name: 'foo'});
+    const connectionStub = {
+      execute: function(query, params){
+        assert.equal(query, 'SELECT FROM tbl_name WHERE col_name = x');
+        assert.deepEqual(params, undefined);
+
+        return [];
+      },
+      release: function() { },
+      connection: {unprepare: function() {}}
+    };
+    sinon.stub(db, 'configure').callsFake(function(config) { });
+    sinon.stub(db, 'getConnection').resolves(connectionStub);
+    db.query('SELECT FROM tbl_name WHERE col_name = x', undefined).then(res => {
+      db.configure.restore();
+      db.getConnection.restore();
       done();
     }).catch(err => {
       console.log('error: ', err);

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -63,20 +63,21 @@ describe('node-mysql', () => {
       release: function() { },
       connection: {unprepare: function() {}}
     };
-    sinon.stub(db, 'configure').callsFake(function(config) { });
-    sinon.stub(db, 'getConnection').resolves(connectionStub);
+    const sandbox = sinon.sandbox.create();
+    sandbox.stub(db, 'configure').callsFake(function(config) { });
+    sandbox.stub(db, 'getConnection').resolves(connectionStub);
     db.bulk('INSERT INTO tbl_name (a,b,c) VALUES ?', [[1,2,3],[4,5, null]]).then(res => {
-      db.configure.restore();
-      db.getConnection.restore();
+      sandbox.restore();
       done();
     }).catch(err => {
       console.log('error: ', err);
+      sandbox.restore();
       assert.equal(err.message, 'should never reach here');
       done();
     });
   });
 
-  it('should add extra placeholders in the prepared query if the corresponding param is an array. params sohuld be flatten if contain arrays.', (done) => {
+  it('should add extra placeholders in the prepared query if the corresponding param is an array', (done) => {
     const db = require('../index')({host: 'mysql', name: 'foo'});
     const connectionStub = {
       execute: function(query, params){
@@ -88,20 +89,23 @@ describe('node-mysql', () => {
       release: function() { },
       connection: {unprepare: function() {}}
     };
-    sinon.stub(db, 'configure').callsFake(function(config) { });
-    sinon.stub(db, 'getConnection').resolves(connectionStub);
-    db.query('SELECT FROM tbl_name WHERE col_name IN (?) AND col_name_1 = ? AND col_name_2 IN (?) AND col_name_3 = ?', [[1,2,3],null,[4,null],5]).then(res => {
-      db.configure.restore();
-      db.getConnection.restore();
+    const sandbox = sinon.sandbox.create();
+    sandbox.stub(db, 'configure').callsFake(function(config) { });
+    sandbox.stub(db, 'getConnection').resolves(connectionStub);
+    db.query('SELECT FROM tbl_name WHERE col_name IN (?) AND col_name_1 = ? AND col_name_2 IN (?) AND col_name_3 = ?',
+      [[1, 2, 3], null, [4, null], 5])
+    .then(res => {
+      sandbox.restore();
       done();
-    }).catch(err => {
+    })
+    .catch(err => {
       console.log('error: ', err);
-      assert.equal(err.message, 'should never reach here');
-      done();
+      sandbox.restore();
+      done(err);
     });
   });
 
-  it('should run the same input query if params do not include arrays. params remain the same as given.', (done) => {
+  it('should run the same input query if params do not include arrays', (done) => {
     const db = require('../index')({host: 'mysql', name: 'foo'});
     const connectionStub = {
       execute: function(query, params){
@@ -113,20 +117,22 @@ describe('node-mysql', () => {
       release: function() { },
       connection: {unprepare: function() {}}
     };
-    sinon.stub(db, 'configure').callsFake(function(config) { });
-    sinon.stub(db, 'getConnection').resolves(connectionStub);
-    db.query('SELECT FROM tbl_name WHERE col_name = ? AND col_name_1 = ?', [1, 2]).then(res => {
-      db.configure.restore();
-      db.getConnection.restore();
+    const sandbox = sinon.sandbox.create();
+    sandbox.stub(db, 'configure').callsFake(function(config) { });
+    sandbox.stub(db, 'getConnection').resolves(connectionStub);
+    db.query('SELECT FROM tbl_name WHERE col_name = ? AND col_name_1 = ?', [1, 2])
+    .then(res => {
+      sandbox.restore();
       done();
-    }).catch(err => {
+    })
+    .catch(err => {
       console.log('error: ', err);
-      assert.equal(err.message, 'should never reach here');
+      sandbox.restore();
       done();
     });
   });
 
-  it('should run the same query if no params provided.', (done) => {
+  it('should run the same query if no params provided', (done) => {
     const db = require('../index')({host: 'mysql', name: 'foo'});
     const connectionStub = {
       execute: function(query, params){
@@ -138,16 +144,18 @@ describe('node-mysql', () => {
       release: function() { },
       connection: {unprepare: function() {}}
     };
-    sinon.stub(db, 'configure').callsFake(function(config) { });
-    sinon.stub(db, 'getConnection').resolves(connectionStub);
-    db.query('SELECT FROM tbl_name WHERE col_name = x', undefined).then(res => {
-      db.configure.restore();
-      db.getConnection.restore();
+    const sandbox = sinon.sandbox.create();
+    sandbox.stub(db, 'configure').callsFake(function(config) { });
+    sandbox.stub(db, 'getConnection').resolves(connectionStub);
+    db.query('SELECT FROM tbl_name WHERE col_name = x', undefined)
+    .then(res => {
+      sandbox.restore();
       done();
-    }).catch(err => {
+    })
+    .catch(err => {
       console.log('error: ', err);
-      assert.equal(err.message, 'should never reach here');
-      done();
+      sandbox.restore();
+      done(err);
     });
   });
 });


### PR DESCRIPTION
Expand placeholders (?) to match the length of their corresponding params if needed (if param is an array, add extra placeholders, if not keep as is).

e.g. 
   query = "WHERE col_name IN (?) AND col_name_1 = ?" 
   params = [[1,2,3], 4], 
we need to add extra placeholders to the first one so it matches the number of array elements, but keep the second placeholder as is because the corresponding param is not an array. 
  reuslt => "WHERE col_name IN (?,?,?)  AND col_name_1 = ?"